### PR TITLE
update htmllint package dependency to version 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "htmllint": "^0.2.4",
+    "htmllint": "^0.6.0",
     "promise": "^6.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Update htmllint version to use more options for html-linting