### PR TITLE
docs(options): remove erroneous "opts" argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ If set to a string, the file path contained in the string will be loaded.
 Type: `Object`
 Default value: `{}`
 
-The object passed to [htmllint](https://github.com/htmllint/htmllint) as the `opts` argument.
-
 ### Usage Examples
 
 #### Default Options
@@ -107,7 +105,7 @@ grunt.initConfig({
   htmllint: {
     options: {
       force: true,
-      opts: { maxerr: 5 }
+      maxerr: 5
     },
     src: [
       'test/fixtures/*.html'


### PR DESCRIPTION
### 1. Summary

In header.

### 2. Environment

+ Operating System:
    + Windows 10 Enterprise LTSB 64-bit EN (local)
    + Ubuntu 14.04.5 LTS (Travis CI)
+ Node.js 10.1.0
+ Grunt 1.0.2
+ grunt-htmllint 0.3.0

### 3. Configuration

See example configuration in [**SashaHtmllint branch of my demo repository**](https://github.com/Kristinita/SashaGruntDebugging/tree/SashaHtmllint).

`SashaHtmllintDebugging.html`:

```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <title>Document</title>
</head>
<body>
    <div class="SashaClass">Sasha Goddess!</div>
    <div class="SashaClass">Sasha Goddess!</div>
    <div class="SashaClass">Sasha Goddess!</div>
    <div class="SashaClass">Sasha Goddess!</div>
    <div class="SashaClass">Sasha Goddess!</div>
    <div class="SashaClass">Sasha Goddess!</div>
    <div class="SashaClass">Sasha Goddess!</div>
    <div class="SashaClass">Sasha Goddess!</div>
</body>
</html>

```

### 4. Behavior before pull request

**If** `Gruntfile.js`:

```javascript
module.exports = function (grunt) {
    grunt.initConfig({
        htmllint: {
            options: {
                force: true,
                opts: {
                maxerr: 5
            }
            },
            src: [
                'SashaHtmllintDebugging.html'
            ]
        }
    });

    grunt.loadNpmTasks('grunt-htmllint');

    grunt.registerTask('default', ['htmllint']);
};

```

9 errors, `maxerr: 5` doesn't accept:

[**Travis CI demonstration**](https://travis-ci.org/Kristinita/SashaGruntDebugging/builds/378581269#L472-L481).

### 5. Behavior after pull request

**Else**:

```javascript
module.exports = function (grunt) {
    grunt.initConfig({
        htmllint: {
            options: {
                force: true,
                maxerr: 5
            },
            src: [
                'SashaHtmllintDebugging.html'
            ]
        }
    });

    grunt.loadNpmTasks('grunt-htmllint');

    grunt.registerTask('default', ['htmllint']);
};

```

5 errors as in options.

[**Travis CI demonstration**](https://travis-ci.org/Kristinita/SashaGruntDebugging/builds/378584851#L475-L480).

Thanks.